### PR TITLE
Add authorization notice

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ $asana->createTask(array(
 ));
 ```
 
+Creating a task for another assignee than yourself will mark the task as private by 
+default. This results in the task not being available for modification through the 
+API anymore. Take a look at the [API Reference](https://asana.com/developers/api-reference/tasks) 
+for more fields of the Task you can directly pass to `createTask`.
+
 #### Adding task to project
 
 ```php


### PR DESCRIPTION
... and add link to API reference for extra fields (like `projects`).

Did struggle with some initial authorization issues because the `projects` field expected an array and did not take a look in the API reference.