### PR TITLE
getUsers(): Allow returning additional fields

### DIFF
--- a/asana.php
+++ b/asana.php
@@ -106,11 +106,18 @@ class Asana
     /**
      * Returns the user records for all users in all workspaces you have access.
      *
+     * @param array $return_fields Fields to return for each user
+     *
+     *                             Valid options: name, email, photo, workspaces
+     *                             Default: name
+     *
+     *                             (@see https://asana.com/developers/api-reference/users)
      * @return string JSON or null
      */
-    public function getUsers()
+    public function getUsers($return_fields = array('name'))
     {
-        return $this->askAsana($this->userUrl);
+        $options = array('opt_fields' => implode(',', $return_fields));
+        return $this->askAsana($this->userUrl . '?' . http_build_query($options));
     }
 
 

--- a/asana.php
+++ b/asana.php
@@ -106,18 +106,17 @@ class Asana
     /**
      * Returns the user records for all users in all workspaces you have access.
      *
-     * @param array $return_fields Fields to return for each user
+     * @param array $opts Array of options to pass to the API
+     *                    (@see https://asana.com/developers/api-reference/users)
      *
-     *                             Valid options: name, email, photo, workspaces
-     *                             Default: name
+     *                    Example: Returning additional fields with 'opt_fields'
+     *                    getUsers(['opt_fields' => 'name,email,photo,workspaces'])
      *
-     *                             (@see https://asana.com/developers/api-reference/users)
      * @return string JSON or null
      */
-    public function getUsers($return_fields = array('name'))
+    public function getUsers(array $opts = array())
     {
-        $options = array('opt_fields' => implode(',', $return_fields));
-        return $this->askAsana($this->userUrl . '?' . http_build_query($options));
+        return $this->askAsana($this->userUrl . '?' . http_build_query($opts));
     }
 
 


### PR DESCRIPTION
Accepts an array of fields to return for each user
Example: getUsers(['name', 'email', 'photos']);


For my use case, I need to find users by email and having one query that returns user names, IDs, *and* email address. This saves me having to call getUserInfo() to get email.

The default hasn't changed at all.