### PR TITLE
Added duplicateProject method

### DIFF
--- a/asana.php
+++ b/asana.php
@@ -639,7 +639,29 @@ class Asana
 
         return $this->askAsana($this->projectsUrl, $data, ASANA_METHOD_POST);
     }
+    
+    /**
+     * Function to duplicate a project (template project) (https://developers.asana.com/docs/duplicate-a-project)
+     *
+     * @param string $projectId
+     * @param array $data Array of data for the project following the Asana API documentation.
+     * Example:
+     *
+     * array(
+     *     "name" => "Foo Project!",
+     *     "notes" => "This is a test project"
+     * )
+     *
+     * @return string JSON or null
+     */
+    public function duplicateProject($projectId, $data)
+    {
+        $data = array('data' => $data);
+        $data = json_encode($data);
 
+        return $this->askAsana($this->projectsUrl . '/' . $projectId . '/duplicate', $data, ASANA_METHOD_POST);
+    }
+    
     /**
      * Returns the full record for a single project.
      *


### PR DESCRIPTION
Recently been looking for a way to create a project based on a template and found out that Asana added this new endpoint: https://forum.asana.com/t/now-available-project-and-task-duplication/49371. This new method creates and returns a job that will asynchronously handle the duplication.